### PR TITLE
Moved H.Notify into a windows only build flag. We are only using H.No…

### DIFF
--- a/AnonWallClient.csproj
+++ b/AnonWallClient.csproj
@@ -47,17 +47,10 @@
 
   <ItemGroup>
     <MauiImage Remove="Resources\Images\appicon.ico" />
-    <MauiImage Remove="Resources\Images\dotnet_bot.png" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
     <Content Include="Resources\Images\appicon.ico">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Resources\Images\dotnet_bot.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -1,5 +1,4 @@
 ﻿using CommunityToolkit.Maui;
-using H.NotifyIcon;
 using Microsoft.Extensions.Logging;
 using AnonWallClient.Background;
 using AnonWallClient.Services;
@@ -10,6 +9,7 @@ using AnonWallClient.Platforms.Android.Services;
 #endif
 #if WINDOWS
 // We reference the namespace, not a specific class
+using H.NotifyIcon;
 using AnonWallClient.Platforms.Windows;
 #endif
 


### PR DESCRIPTION
…tifyIcons for the windows build for the stytem tray icon on windows. Changed Icon to be only compiled for windows builds.